### PR TITLE
Fix Render build by adding requirements and FastAPI app

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,20 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
 
+api = FastAPI()
+
+class EstimateRequest(BaseModel):
+    volume: float  # cubic feet
+    distance: float  # miles
+
+class EstimateResponse(BaseModel):
+    cost: float
+
+@api.post('/estimate', response_model=EstimateResponse)
+def estimate(request: EstimateRequest):
+    # simple cost calculation
+    base_rate = 100
+    volume_rate = 1.5
+    distance_rate = 0.5
+    cost = base_rate + request.volume * volume_rate + request.distance * distance_rate
+    return {'cost': round(cost, 2)}

--- a/placeholder.txt
+++ b/placeholder.txt
@@ -1,1 +1,0 @@
-repo placeholder, delete asap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- implement a small FastAPI application with a `/estimate` endpoint
- add `requirements.txt` so Render's build command succeeds
- remove placeholder file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be8bfa8c483208fbf8fede03cff4c