### PR TITLE
Use data files for moving estimate calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ This repo now includes sample data used for estimating move costs.
 - `data/box_carton_information.txt` and `data/packing_weight_volume_pricing.tsv` provide box and packing details.
 - `data/follow_up_questions.txt` lists questions the agent can use when gathering details.
 
+
+## API Usage
+
+Send a `POST` request to `/estimate` with a JSON body specifying the items to move, distance in miles, and the date of the move. Item names must match entries in `data/estimation_weights_volumes_categories.json` (aliases are accepted).
+
+Example request:
+
+```json
+{
+  "items": {"bed_king_mattress": 1, "bar_stool": 4},
+  "distance_miles": 15,
+  "move_date": "2025-07-08"
+}
+```
+
+The response includes the total cost and a breakdown of labor hours, protective materials charges, number of movers and trucks, and the calculated weight and volume.

--- a/main.py
+++ b/main.py
@@ -1,20 +1,121 @@
-from fastapi import FastAPI
-from pydantic import BaseModel
+import json
+from datetime import datetime
+from math import ceil
+from pathlib import Path
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+DATA_DIR = Path(__file__).parent / "data"
+
+# load item weights/volumes
+with open(DATA_DIR / "estimation_weights_volumes_categories.json", "r") as f:
+    ITEMS = json.load(f)
+
+# build alias -> weight/volume mapping
+ITEM_LOOKUP: Dict[str, Dict[str, float]] = {}
+for item in ITEMS:
+    info = {"weight": item["weight_lbs"], "volume": item["volume_cuft"]}
+    for alias in item.get("aliases", []):
+        ITEM_LOOKUP[alias.lower()] = info
+    ITEM_LOOKUP[item["id"].lower()] = info
+    ITEM_LOOKUP[item["name"].lower()] = info
+
+# load pricing rules
+with open(DATA_DIR / "moving_rules.json", "r") as f:
+    RULES = json.load(f)["movingQuoterContext"]
 
 api = FastAPI()
 
+
 class EstimateRequest(BaseModel):
-    volume: float  # cubic feet
-    distance: float  # miles
+    items: Dict[str, int] = Field(
+        ...,
+        description="Mapping of item names/ids to quantities"
+    )
+    distance_miles: float = Field(..., gt=0)
+    move_date: datetime = Field(..., description="Date of move (YYYY-MM-DD)")
+
 
 class EstimateResponse(BaseModel):
     cost: float
+    breakdown: Dict[str, float]
 
-@api.post('/estimate', response_model=EstimateResponse)
-def estimate(request: EstimateRequest):
-    # simple cost calculation
-    base_rate = 100
-    volume_rate = 1.5
-    distance_rate = 0.5
-    cost = base_rate + request.volume * volume_rate + request.distance * distance_rate
-    return {'cost': round(cost, 2)}
+
+def _resolve_items(items: Dict[str, int]):
+    weight = 0.0
+    volume = 0.0
+    unknown = []
+    for name, qty in items.items():
+        info = ITEM_LOOKUP.get(name.lower())
+        if info is None:
+            unknown.append(name)
+            continue
+        weight += info["weight"] * qty
+        volume += info["volume"] * qty
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown items: {', '.join(unknown)}")
+    return weight, volume
+
+
+def _get_rates(distance: float, move_date: datetime):
+    weekday = move_date.weekday()
+    weekend = weekday >= 4  # Friday=4, Saturday=5
+    move_type = "localMoves" if distance <= 30 else "intrastateMoves"
+    pricing = RULES["pricing"][move_type]
+    if weekend:
+        rates = pricing["ratesFridayToSaturday"]
+    else:
+        rates = pricing["ratesMondayToThursday"]
+    return rates["moverRatePerHour"], rates["truckRatePerHour"]
+
+
+def _num_movers(weight: float) -> int:
+    if weight <= 4000:
+        return 2
+    extra = max(weight - 4000, 0)
+    return 2 + ceil(extra / 2500)
+
+
+def _num_trucks(weight: float) -> int:
+    return ceil(weight / 8000)
+
+
+def _estimate_hours(weight: float, movers: int, distance: float) -> float:
+    base_rate_per_mover = 310.0
+    hours = weight / (base_rate_per_mover * movers)
+    hours += 1.0  # travel charge
+    if distance <= 30:
+        hours += 20 / 60
+    else:
+        # approximate actual drive time plus warehouse trips
+        drive = max(distance / 50, 0.5)
+        hours += drive + 1.0  # 0.5 each way warehouse
+    return max(hours, 3.0)
+
+
+@api.post("/estimate", response_model=EstimateResponse)
+def estimate(req: EstimateRequest):
+    weight, volume = _resolve_items(req.items)
+    movers = _num_movers(weight)
+    trucks = _num_trucks(weight)
+    mover_rate, truck_rate = _get_rates(req.distance_miles, req.move_date)
+    hours = _estimate_hours(weight, movers, req.distance_miles)
+
+    labor = (mover_rate * movers + truck_rate * trucks) * hours
+    protective = 5.0 * ceil(weight / 1000)
+    cost = labor + protective
+    return {
+        "cost": round(cost, 2),
+        "breakdown": {
+            "labor": round(labor, 2),
+            "protective": round(protective, 2),
+            "hours": round(hours, 2),
+            "movers": movers,
+            "trucks": trucks,
+            "weight": weight,
+            "volume": volume,
+        },
+    }
+


### PR DESCRIPTION
## Summary
- load item weights and pricing rules from the data directory
- compute rates based on items, distance and date
- add detailed cost breakdown in API response
- document new `/estimate` request format

## Testing
- `python -m py_compile main.py`
- ❌ `pip install fastapi uvicorn` (failed due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_686bee5da63883208268269d66dc952c