### PR TITLE
Validate item quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo now includes sample data used for estimating move costs.
 
 ## API Usage
 
-Send a `POST` request to `/estimate` with a JSON body specifying the items to move, distance in miles, and the date of the move. Item names must match entries in `data/estimation_weights_volumes_categories.json` (aliases are accepted).
+Send a `POST` request to `/estimate` with a JSON body specifying the items to move, distance in miles, and the date of the move. Item names must match entries in `data/estimation_weights_volumes_categories.json` (aliases are accepted). Quantities must be positive integers or the API will return `400 Quantity must be positive`.
 
 Example request:
 

--- a/main.py
+++ b/main.py
@@ -48,6 +48,8 @@ def _resolve_items(items: Dict[str, int]):
     volume = 0.0
     unknown = []
     for name, qty in items.items():
+        if not isinstance(qty, int) or qty <= 0:
+            raise HTTPException(status_code=400, detail="Quantity must be positive")
         info = ITEM_LOOKUP.get(name.lower())
         if info is None:
             unknown.append(name)


### PR DESCRIPTION
## Summary
- ensure each quantity in `_resolve_items` is a positive integer
- document quantity validation in the API usage section

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686c08e2d7488320b0a0dfd811986887