### PR TITLE
Clarify Render config and health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This repository holds the FastAPI code used to estimate moving costs. Below are 
    - **Environment**: Python 3.11 or your preferred version.
    - **Build Command:** `pip install -r requirements.txt` (make sure `requirements.txt` exists and lists `fastapi` and `uvicorn`).
    - **Start Command:** `uvicorn main:api --host 0.0.0.0 --port $PORT`
+     - Do **not** replace `$PORT` with a fixed value. Render sets this
+       environment variable automatically. If the service doesn't listen
+       on that port, Render's health check will kill the process.
 4. **Select Plan and Deploy**
    - Choose a free or paid plan based on traffic needs.
    - Click **Create Web Service**. Render will build and start the service.

--- a/render.yaml
+++ b/render.yaml
@@ -4,3 +4,4 @@ services:
     env: python
     buildCommand: "pip install -r requirements.txt"
     startCommand: "uvicorn main:api --host 0.0.0.0 --port $PORT"
+    healthCheckPath: /


### PR DESCRIPTION
## Summary
- add explicit `healthCheckPath` in `render.yaml`
- document that `$PORT` must not be replaced when deploying to Render

## Testing
- `python3 -m py_compile main.py`
- `python3 -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686c1fb55e148320811ebb25fb57ce21