### PR TITLE
Add real ElevenLabs webhook URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,27 @@ This repository holds the FastAPI code used to estimate moving costs. Below are 
    - Choose a free or paid plan based on traffic needs.
    - Click **Create Web Service**. Render will build and start the service.
 5. **Test the Endpoint**
-   - Once deployed, visit `https://<your-service>.onrender.com/docs` to view the OpenAPI docs and verify `/estimate` works.
+   - Once deployed, visit `https://estimate-moving-price.onrender.com/docs` to view the OpenAPI docs and verify `/estimate` works.
 6. **Use with ElevenLabs AI Agent**
    - Register a new tool in the ElevenLabs interface using the base URL of your Render service and the endpoint `POST /estimate`.
    - The complete webhook configuration is provided in `elevenlabs_tool.json`. Import this file directly or copy its contents when creating the tool.
+
+## ElevenLabs Tool Form Example
+
+When creating the webhook tool in the ElevenLabs UI, fill out the form using these values:
+
+- **Name**: `Estimate_Move_Price`
+- **Description**: Determine the estimated cost of the move based on the caller's inventory, distance and move date.
+- **Method**: `POST`
+- **URL**: `https://estimate-moving-price.onrender.com/estimate`
+- **Response timeout**: `10`
+- **Authentication**: none
+- **Headers**: leave blank
+- **Path parameters**: none
+- **Query parameters**: none
+- **Request body**: JSON object containing `items`, `distance_miles`, and `move_date`.
+
+This mirrors the contents of `elevenlabs_tool.json` and allows the agent to call the service with dynamic values.
 
 Your FastAPI service is now ready to be called by the agent.
 


### PR DESCRIPTION
## Summary
- replace placeholder Render URL in the README with the live service URL

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686c5a4321e08320a3306409579456d7