### PR TITLE
Improve request parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This repo now includes sample data used for estimating move costs.
 
 ## API Usage
 
-Send a `POST` request to `/estimate` with a JSON body specifying the items to move, distance in miles, and the date of the move. Item names must match entries in `data/estimation_weights_volumes_categories.json` (aliases are accepted). Quantities must be positive integers or the API will return `400 Quantity must be positive`.
+Send a `POST` request to `/estimate` with a JSON body specifying the items to move, distance in miles, and the date of the move. Item names are matched against `data/estimation_weights_volumes_categories.json`; close matches are accepted so minor variations (e.g., "grand piano" vs "piano - grand") will still resolve. Quantities must be positive integers or the API will return `400 Quantity must be positive`.
 
 Example request:
 
@@ -72,6 +72,10 @@ Example request:
   "move_date": "2025-07-08"
 }
 ```
+
+The service also accepts a variant where `distance_miles` and `move_date`
+appear inside the `items` object. These fields will be extracted automatically
+for compatibility with agent tools that send all values together.
 
 The response includes the total cost and a breakdown of labor hours, protective materials charges, number of movers and trucks, and the calculated weight and volume.
 

--- a/data/estimation_weights_volumes_categories.json
+++ b/data/estimation_weights_volumes_categories.json
@@ -145,5 +145,7 @@
  { "id": "dining_table_large", "name": "Dining Table - Large", "category": "dining", "volume_cuft": 30.0, "weight_lbs": 195.0, "aliases": [ "dining table - large" ] },
  { "id": "dining_table_medium", "name": "Dining Table - Medium", "category": "dining", "volume_cuft": 25.0, "weight_lbs": 175.0, "aliases": [ "dining table - medium" ] },
  { "id": "dining_table_small", "name": "Dining Table - Small", "category": "dining", "volume_cuft": 20.0, "weight_lbs": 140.0, "aliases": [ "dining table - small" ] },
- { "id": "dishwasher", "name": "Dishwasher", "category": "dishwasher", "volume_cuft": 20.0, "weight_lbs": 140.0, "aliases": [ "dishwasher" ] }
+ { "id": "dishwasher", "name": "Dishwasher", "category": "dishwasher", "volume_cuft": 20.0, "weight_lbs": 140.0, "aliases": [ "dishwasher" ] },
+ { "id": "piano_upright", "name": "Piano - Upright", "category": "piano", "volume_cuft": 70.0, "weight_lbs": 500.0, "aliases": [ "upright piano", "piano upright", "upright" ] },
+ { "id": "piano_grand", "name": "Piano - Grand", "category": "piano", "volume_cuft": 120.0, "weight_lbs": 700.0, "aliases": [ "grand piano", "baby grand piano", "concert piano", "grand" ] }
 ]


### PR DESCRIPTION
## Summary
- allow distance and date to be nested within `items`
- update docs about alternative request format

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686d1bdc07b48320b95ea4a0924d3b14