### PR TITLE
Fix missing pydantic skip_on_failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ class EstimateRequest(BaseModel):
                 values["move_date"] = items.pop("move_date")
         return values
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def _require_fields(cls, values):
         if values.get("distance_miles") is None:
             raise ValueError("distance_miles is required")


### PR DESCRIPTION
## Summary
- handle post-Pydantic 2 `root_validator` requirements

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686d4ab8e3cc8320a1dab6e73b584509