### PR TITLE
Improve request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ objects, each with `items`/`item` and `Qty` fields, for example:
 Such lists will be converted to the required mapping internally. Requests may
 also be wrapped in an array at the top level; the API will unwrap a single
 object automatically. Any other structure will be rejected with a `400` error.
+If `items` is missing or cannot be converted into a mapping, the service now
+returns a clear `400` response instead of raising an internal error.
 
 The service also accepts a variant where `distance_miles` and `move_date`
 appear inside the `items` object. These fields will be extracted automatically

--- a/main.py
+++ b/main.py
@@ -55,15 +55,18 @@ class EstimateRequest(BaseModel):
                 raise ValueError("Request body must be a JSON object")
         if not isinstance(values, dict):
             raise ValueError("Request body must be a JSON object")
+
         # items may arrive in several forms depending on the calling tool
         items = values.get("items")
+        if items is None:
+            raise ValueError("items field is required")
 
         # JSON-encoded string
         if isinstance(items, str):
             try:
                 items = json.loads(items)
             except json.JSONDecodeError:
-                raise ValueError("items must be a JSON object")
+                raise ValueError("items must be a JSON object or list")
 
         # list-based forms sent by some calling tools
         if isinstance(items, list):
@@ -97,6 +100,8 @@ class EstimateRequest(BaseModel):
                     except (TypeError, ValueError):
                         raise ValueError("quantity values must be integers")
                 items = converted
+        elif not isinstance(items, dict):
+            raise ValueError("items must be a JSON object or list")
 
         values["items"] = items
 


### PR DESCRIPTION
## Summary
- improve error handling when `items` is not present or not a dict
- document the stricter validation in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f92328c8320bd89da5971c33469